### PR TITLE
Swift 5 / Xcode 10.2 readiness

### DIFF
--- a/Sources/WWLayout/Insets.swift
+++ b/Sources/WWLayout/Insets.swift
@@ -48,11 +48,11 @@ public struct Insets {
     }
 }
 
-public extension Insets {
+extension Insets {
     public static let zero = Insets(0)
 }
 
-public extension Insets {
+extension Insets {
     
     /// Set all edges of the inset to the same amount.
     public init(_ allEdgesAmount: CGFloat) {

--- a/Sources/WWLayout/Layout+Size.swift
+++ b/Sources/WWLayout/Layout+Size.swift
@@ -30,7 +30,7 @@
 
 import UIKit
 
-public extension Layout {
+extension Layout {
     
     //size(80)
     //  size(80, 200)

--- a/Sources/WWLayout/LayoutRelation.swift
+++ b/Sources/WWLayout/LayoutRelation.swift
@@ -39,7 +39,7 @@ public enum LayoutRelation {
 
 // MARK: - constraint creation helpers
 
-internal extension LayoutRelation {
+extension LayoutRelation {
     
     /// Get the corresponding NSLayoutRelation
     internal var nsRelation: LayoutConstraint.Relation {

--- a/Sources/WWLayout/UIView+Layout.swift
+++ b/Sources/WWLayout/UIView+Layout.swift
@@ -30,7 +30,7 @@
 
 import UIKit
 
-public extension UIView {
+extension UIView {
     
     /// Access to auto layout constrains for the view
     public var layout: Layout { return Layout(self) }

--- a/WWLayout.xcodeproj/project.pbxproj
+++ b/WWLayout.xcodeproj/project.pbxproj
@@ -213,12 +213,12 @@
 				TargetAttributes = {
 					798F251F1FD18FA4006E6A44 = {
 						CreatedOnToolsVersion = 9.1;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 					798F25281FD18FA4006E6A44 = {
 						CreatedOnToolsVersion = 9.1;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 				};

--- a/WWLayoutExample/WWLayoutExample.xcodeproj/project.pbxproj
+++ b/WWLayoutExample/WWLayoutExample.xcodeproj/project.pbxproj
@@ -257,18 +257,18 @@
 				TargetAttributes = {
 					798F25501FD190AB006E6A44 = {
 						CreatedOnToolsVersion = 9.1;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 					798F25641FD190AB006E6A44 = {
 						CreatedOnToolsVersion = 9.1;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 798F25501FD190AB006E6A44;
 					};
 					798F256F1FD190AB006E6A44 = {
 						CreatedOnToolsVersion = 9.1;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 798F25501FD190AB006E6A44;
 					};


### PR DESCRIPTION
Removes redundant enum access control warnings, and sets last migration check to Xcode 10.2.