### PR TITLE
Point branch of swift package back to develop for general consumption

### DIFF
--- a/WWLayoutExample/WWLayoutTV/WWLayoutTV.xcodeproj/project.pbxproj
+++ b/WWLayoutExample/WWLayoutTV/WWLayoutTV.xcodeproj/project.pbxproj
@@ -463,7 +463,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ww-tech/wwlayout";
 			requirement = {
-				branch = feature/swiftpm;
+				branch = develop;
 				kind = branch;
 			};
 		};


### PR DESCRIPTION
Had to point it at a feature branch to prime the pump.  Now that it's merged, this should point back to `develop`.