### PR TITLE
Add support for Swift 5.2 in Xcode 11.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,20 @@ jobs:
           swift: '5.1'
           device: 'iPhone 11'
 
+  build-and-test-swift52:
+    <<: *defaults
+    macos:
+      xcode: 11.4.0
+    steps:
+      - checkout
+      - install_dependencies
+      - build:
+          swift: '5.2'
+          device: 'iPhone 7'
+      - build:
+          swift: '5.2'
+          device: 'iPhone XS'
+
   build-and-test-swiftpm:
     <<: *defaults
     macos:
@@ -120,6 +134,9 @@ workflows:
           requires:
             - build-gem-cache
       - build-and-test-swift51:
+          requires:
+            - build-gem-cache
+      - build-and-test-swift52:
           requires:
             - build-gem-cache
       - build-and-test-swiftpm:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     <a href="https://codeclimate.com/repos/5bd1ca9c535ea53834001d51/maintainability"><img src="https://api.codeclimate.com/v1/badges/d42334bce58294611b8b/maintainability" /></a>
     <a href="https://codeclimate.com/repos/5bd1ca9c535ea53834001d51/test_coverage"><img src="https://api.codeclimate.com/v1/badges/d42334bce58294611b8b/test_coverage" /></a>
     -->
-    <img src="https://img.shields.io/badge/Swift-4.0%20--%205.1-blueviolet.svg?style=flat" />
+    <img src="https://img.shields.io/badge/Swift-4.0%20--%205.2-blueviolet.svg?style=flat" />
     <img src="https://img.shields.io/badge/iOS-10.3%20--%2013.x-blue.svg?style=flat" />
 </p>
 

--- a/WWLayout.podspec
+++ b/WWLayout.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.license         = "Apache-2.0"
   s.author          = { "Steven Grosmark" => "steven.grosmark@weightwatchers.com" }
   s.platform        = :ios, "9.0"
-  s.swift_versions  = '4.0', '4.2', '5', '5.1'
+  s.swift_versions  = '4.0', '4.2', '5', '5.1', '5.2'
   
   s.source          = { :git => "https://github.com/ww-tech/wwlayout.git", :tag => s.version.to_s }
   s.source_files    = "Sources/WWLayout", "Sources/WWLayout/**/*.{h,m,swift}"


### PR DESCRIPTION
No code changes needs to support Swift 5.2.

This PR just adds a new CircleCI job using Xcode 11.4 to compile with Swift 5.2.